### PR TITLE
Add Formula for PHP 7.1 & Update to 4.0.7

### DIFF
--- a/Formula/php53-tideways.rb
+++ b/Formula/php53-tideways.rb
@@ -4,7 +4,7 @@ class Php53Tideways < AbstractTidewaysPhpExtension
     init
     homepage 'https://github.com/tideways/php-profiler-extension'
     head 'https://github.com/tideways/php-profiler-extension.git'
-    url 'https://github.com/tideways/php-profiler-extension/archive/v4.0.5.zip'
+    url 'https://github.com/tideways/php-profiler-extension/archive/v4.0.7.zip'
     version 'v4.0.5'
 
     def self.init opts=[]

--- a/Formula/php53-tideways.rb
+++ b/Formula/php53-tideways.rb
@@ -5,6 +5,7 @@ class Php53Tideways < AbstractTidewaysPhpExtension
     homepage 'https://github.com/tideways/php-profiler-extension'
     head 'https://github.com/tideways/php-profiler-extension.git'
     url 'https://github.com/tideways/php-profiler-extension/archive/v4.0.7.zip'
+    sha256 'c3e7b243de695d38026e1741a385bbd664f450d5bd786a98d5c5c4858a7494d9'
     version 'v4.0.5'
 
     def self.init opts=[]

--- a/Formula/php54-tideways.rb
+++ b/Formula/php54-tideways.rb
@@ -4,7 +4,7 @@ class Php54Tideways < AbstractTidewaysPhpExtension
     init
     homepage 'https://github.com/tideways/php-profiler-extension'
     head 'https://github.com/tideways/php-profiler-extension.git'
-    url 'https://github.com/tideways/php-profiler-extension/archive/v4.0.5.zip'
+    url 'https://github.com/tideways/php-profiler-extension/archive/v4.0.7.zip'
     version 'v4.0.5'
 
     def self.init opts=[]

--- a/Formula/php54-tideways.rb
+++ b/Formula/php54-tideways.rb
@@ -5,6 +5,7 @@ class Php54Tideways < AbstractTidewaysPhpExtension
     homepage 'https://github.com/tideways/php-profiler-extension'
     head 'https://github.com/tideways/php-profiler-extension.git'
     url 'https://github.com/tideways/php-profiler-extension/archive/v4.0.7.zip'
+    sha256 'c3e7b243de695d38026e1741a385bbd664f450d5bd786a98d5c5c4858a7494d9'
     version 'v4.0.5'
 
     def self.init opts=[]

--- a/Formula/php55-tideways.rb
+++ b/Formula/php55-tideways.rb
@@ -5,6 +5,7 @@ class Php55Tideways < AbstractTidewaysPhpExtension
     homepage 'https://github.com/tideways/php-profiler-extension'
     head 'https://github.com/tideways/php-profiler-extension.git'
     url 'https://github.com/tideways/php-profiler-extension/archive/v4.0.7.zip'
+    sha256 'c3e7b243de695d38026e1741a385bbd664f450d5bd786a98d5c5c4858a7494d9'
     version 'v4.0.5'
 
     def self.init opts=[]

--- a/Formula/php55-tideways.rb
+++ b/Formula/php55-tideways.rb
@@ -4,7 +4,7 @@ class Php55Tideways < AbstractTidewaysPhpExtension
     init
     homepage 'https://github.com/tideways/php-profiler-extension'
     head 'https://github.com/tideways/php-profiler-extension.git'
-    url 'https://github.com/tideways/php-profiler-extension/archive/v4.0.5.zip'
+    url 'https://github.com/tideways/php-profiler-extension/archive/v4.0.7.zip'
     version 'v4.0.5'
 
     def self.init opts=[]

--- a/Formula/php56-tideways.rb
+++ b/Formula/php56-tideways.rb
@@ -4,7 +4,7 @@ class Php56Tideways < AbstractTidewaysPhpExtension
     init
     homepage 'https://github.com/tideways/php-profiler-extension'
     head 'https://github.com/tideways/php-profiler-extension.git'
-    url 'https://github.com/tideways/php-profiler-extension/archive/v4.0.5.zip'
+    url 'https://github.com/tideways/php-profiler-extension/archive/v4.0.7.zip'
     version 'v4.0.5'
 
     def self.init opts=[]

--- a/Formula/php56-tideways.rb
+++ b/Formula/php56-tideways.rb
@@ -5,6 +5,7 @@ class Php56Tideways < AbstractTidewaysPhpExtension
     homepage 'https://github.com/tideways/php-profiler-extension'
     head 'https://github.com/tideways/php-profiler-extension.git'
     url 'https://github.com/tideways/php-profiler-extension/archive/v4.0.7.zip'
+    sha256 'c3e7b243de695d38026e1741a385bbd664f450d5bd786a98d5c5c4858a7494d9'
     version 'v4.0.5'
 
     def self.init opts=[]

--- a/Formula/php70-tideways.rb
+++ b/Formula/php70-tideways.rb
@@ -5,6 +5,7 @@ class Php70Tideways < AbstractTidewaysPhpExtension
     homepage 'https://github.com/tideways/php-profiler-extension'
     head 'https://github.com/tideways/php-profiler-extension.git'
     url 'https://github.com/tideways/php-profiler-extension/archive/v4.0.7.zip'
+    sha256 'c3e7b243de695d38026e1741a385bbd664f450d5bd786a98d5c5c4858a7494d9'
     version 'v4.0.5'
 
     def self.init opts=[]

--- a/Formula/php70-tideways.rb
+++ b/Formula/php70-tideways.rb
@@ -4,7 +4,7 @@ class Php70Tideways < AbstractTidewaysPhpExtension
     init
     homepage 'https://github.com/tideways/php-profiler-extension'
     head 'https://github.com/tideways/php-profiler-extension.git'
-    url 'https://github.com/tideways/php-profiler-extension/archive/v4.0.5.zip'
+    url 'https://github.com/tideways/php-profiler-extension/archive/v4.0.7.zip'
     version 'v4.0.5'
 
     def self.init opts=[]

--- a/Formula/php71-tideways.rb
+++ b/Formula/php71-tideways.rb
@@ -5,6 +5,7 @@ class Php71Tideways < AbstractTidewaysPhpExtension
     homepage 'https://github.com/tideways/php-profiler-extension'
     head 'https://github.com/tideways/php-profiler-extension.git'
     url 'https://github.com/tideways/php-profiler-extension/archive/v4.0.7.zip'
+    sha256 'c3e7b243de695d38026e1741a385bbd664f450d5bd786a98d5c5c4858a7494d9'
     version 'v4.0.5'
 
     def self.init opts=[]

--- a/Formula/php71-tideways.rb
+++ b/Formula/php71-tideways.rb
@@ -4,7 +4,7 @@ class Php71Tideways < AbstractTidewaysPhpExtension
     init
     homepage 'https://github.com/tideways/php-profiler-extension'
     head 'https://github.com/tideways/php-profiler-extension.git'
-    url 'https://github.com/tideways/php-profiler-extension/archive/v4.0.5.zip'
+    url 'https://github.com/tideways/php-profiler-extension/archive/v4.0.7.zip'
     version 'v4.0.5'
 
     def self.init opts=[]

--- a/Formula/php71-tideways.rb
+++ b/Formula/php71-tideways.rb
@@ -1,0 +1,15 @@
+require File.expand_path("../../Abstract/abstract-tideways-php-extension.rb", __FILE__)
+
+class Php71Tideways < AbstractTidewaysPhpExtension
+    init
+    homepage 'https://github.com/tideways/php-profiler-extension'
+    head 'https://github.com/tideways/php-profiler-extension.git'
+    url 'https://github.com/tideways/php-profiler-extension/archive/v4.0.5.zip'
+    version 'v4.0.5'
+
+    def self.init opts=[]
+        super()
+        depends_on "php71" => opts if build.with?('homebrew-php')
+    end
+end
+

--- a/Formula/tideways-cli.rb
+++ b/Formula/tideways-cli.rb
@@ -5,13 +5,13 @@ class TidewaysCli < Formula
 
     url 'https://s3-eu-west-1.amazonaws.com/qafoo-profiler/downloads/tideways-cli_0.2.3_macos_amd64.tar.gz' if MacOS.prefer_64_bit?
     url 'https://s3-eu-west-1.amazonaws.com/qafoo-profiler/downloads/tideways-cli_0.2.3_macos_i386.tar.gz' if not MacOS.prefer_64_bit?
-    sha1 'e7784b9f04f275bf2482308da4cd40d5baf4a468' if MacOS.prefer_64_bit?
-    sha1 '808d553241448c30a87c86cd1474367d4205b2af' if not MacOS.prefer_64_bit?
+    sha256 '651b9ce8b77dd8f0021458ad95789e13530737d3fd8d141555cd0b151033481d' if MacOS.prefer_64_bit?
+    sha256 'dbc5538458d485938f25285092eead8e1c6cdfeae5aa72ea6d6441ed8f79cdb5' if not MacOS.prefer_64_bit?
     version 'v0.2.3'
 
     def install
         bin.install "tideways"
-    end 
+    end
 
     def caveats
         return <<-EOS.undent

--- a/Formula/tideways-daemon.rb
+++ b/Formula/tideways-daemon.rb
@@ -5,8 +5,8 @@ class TidewaysDaemon < Formula
 
     url 'https://s3-eu-west-1.amazonaws.com/qafoo-profiler/downloads/tideways-daemon_macos_amd64-1.3.7.tar.gz'  if MacOS.prefer_64_bit?
     url 'https://s3-eu-west-1.amazonaws.com/qafoo-profiler/downloads/tideways-daemon_macos_i386-1.3.7.tar.gz'  if not MacOS.prefer_64_bit?
-    sha1 '589bb94d2230c67c6394db1fc2b00d1ab594b72d' if MacOS.prefer_64_bit?
-    sha1 '0153183f4e120a21b11344c6d5067289538ca655' if not MacOS.prefer_64_bit?
+    sha256 'a4ea4ca1285dd9a9a5b20d5a01e43c753a94a92299d4e048da5a8167ae9ef310' if MacOS.prefer_64_bit?
+    sha256 '3d547bed7240739eeaa95cb0e88144e4a12d279d40cbc53becb26e9e1ee49eb8' if not MacOS.prefer_64_bit?
 
     def bin_name
         return "tideways-daemon"


### PR DESCRIPTION
This pull requests
* adds a formula for PHP 7.1
* updates the PHP extension to 4.0.7
* Adds SHA256 checksums for the PHP extension
* Migrates all other checksums to SHA256 since SHA1 is disabled in homebrew now

This also fixes https://github.com/tideways/homebrew-profiler/issues/2