### PR TITLE
Add PHP 8.0-8.2 Formulas 

### DIFF
--- a/Abstract/abstract-tideways-php-extension.rb
+++ b/Abstract/abstract-tideways-php-extension.rb
@@ -1,0 +1,83 @@
+# typed: false
+# frozen_string_literal: true
+# https://raw.githubusercontent.com/shivammathur/homebrew-extensions/master/Abstract/abstract-php-extension.rb
+
+# Abstract class for PHP extensions
+class AbstractTidewaysPhpExtension < Formula
+  desc "Abstract class for PHP Extension Formula"
+  homepage "https://github.com/shivammathur/homebrew-extensions"
+  license "Propriortary"
+
+  def initialize(*)
+    super
+    @priority = self.class.priority || "20"
+  end
+
+  def caveats
+    <<~EOS
+      To finish installing #{extension} for PHP #{php_version}:
+        * #{config_filepath} was created,"
+          do not forget to remove it upon extension removal."
+        * Validate installation by running php -m
+    EOS
+  end
+
+  test do
+    output = shell_output("#{Formula[php_formula].opt_bin}/php -m").downcase
+    assert_match(/#{extension.downcase}/, output, "failed to find extension in php -m output")
+  end
+
+  private
+
+  attr_reader :priority
+
+  delegate [:php_version, :extension] => :"self.class"
+
+  def module_path
+    opt_prefix / "#{extension}-php-#{php_version}.so"
+  end
+
+  def config_file_content
+    <<~EOS
+      extension="#{module_path}"
+      tideways.api_key=
+      tideways.connection=tcp://127.0.0.1:9135
+    EOS
+  rescue error
+    raise error
+  end
+
+  def config_scandir_path
+    etc / "php" / php_version / "conf.d"
+  end
+
+  def config_filepath
+    config_scandir_path / "#{priority}-#{extension}.ini"
+  end
+
+  def write_config_file
+    Dir[config_scandir_path / "*#{extension}*.ini"].each do |ini_file|
+      rm ini_file
+    end
+    config_scandir_path.mkpath
+    config_filepath.write(config_file_content)
+  end
+
+  class << self
+    attr_reader :php_version, :extension
+
+    attr_rw :priority
+
+    def parse_extension(matches)
+      @extension = matches[1].downcase if matches
+      @extension.gsub("pecl", "").gsub("pdo", "pdo_").gsub("xdebug2", "xdebug").gsub(/phalcon\d+/, "phalcon")
+    end
+
+    def init
+      class_name = name.split("::").last
+      matches = /(\w+)AT(\d)(\d)/.match(class_name)
+      @extension = "tideways"
+      @php_version = "#{matches[2]}.#{matches[3]}" if matches
+    end
+  end
+end

--- a/Abstract/abstract-tideways-php-extension.rb
+++ b/Abstract/abstract-tideways-php-extension.rb
@@ -4,9 +4,8 @@
 
 # Abstract class for PHP extensions
 class AbstractTidewaysPhpExtension < Formula
-  desc "Abstract class for PHP Extension Formula"
-  homepage "https://github.com/shivammathur/homebrew-extensions"
-  license "Propriortary"
+  desc "Tideways PHP Profiler Extension"
+  homepage 'https://tideways.com'
 
   def initialize(*)
     super

--- a/Formula/tideways-php@8.0.rb
+++ b/Formula/tideways-php@8.0.rb
@@ -1,0 +1,17 @@
+# typed: false
+# frozen_string_literal: true
+
+require File.expand_path("../Abstract/abstract-tideways-php-extension", __dir__)
+
+class TidewaysPhpAT80 < AbstractTidewaysPhpExtension
+  init
+  desc "Tideways PHP Profiler"
+  homepage "https://tideways.com"
+  url "https://s3-eu-west-1.amazonaws.com/tideways/extension/5.5.18/tideways-php-5.5.18-macos-arm.tar.gz"
+  sha256 "70362477568fd38edbc0178978481b6feed04b0b8d34667b77ef014dd3033010"
+
+  def install
+    prefix.install "tideways-php-#{php_version}.so"
+    write_config_file
+  end
+end

--- a/Formula/tideways-php@8.0.rb
+++ b/Formula/tideways-php@8.0.rb
@@ -5,10 +5,9 @@ require File.expand_path("../Abstract/abstract-tideways-php-extension", __dir__)
 
 class TidewaysPhpAT80 < AbstractTidewaysPhpExtension
   init
-  desc "Tideways PHP Profiler"
-  homepage "https://tideways.com"
   url "https://s3-eu-west-1.amazonaws.com/tideways/extension/5.5.18/tideways-php-5.5.18-macos-arm.tar.gz"
   sha256 "70362477568fd38edbc0178978481b6feed04b0b8d34667b77ef014dd3033010"
+  version "5.5.18"
 
   def install
     prefix.install "tideways-php-#{php_version}.so"

--- a/Formula/tideways-php@8.1.rb
+++ b/Formula/tideways-php@8.1.rb
@@ -5,10 +5,9 @@ require File.expand_path("../Abstract/abstract-tideways-php-extension", __dir__)
 
 class TidewaysPhpAT81 < AbstractTidewaysPhpExtension
   init
-  desc "Tideways PHP Profiler"
-  homepage "https://tideways.com"
   url "https://s3-eu-west-1.amazonaws.com/tideways/extension/5.5.18/tideways-php-5.5.18-macos-arm.tar.gz"
   sha256 "70362477568fd38edbc0178978481b6feed04b0b8d34667b77ef014dd3033010"
+  version "5.5.18"
 
   def install
     prefix.install "tideways-php-#{php_version}.so"

--- a/Formula/tideways-php@8.1.rb
+++ b/Formula/tideways-php@8.1.rb
@@ -1,0 +1,17 @@
+# typed: false
+# frozen_string_literal: true
+
+require File.expand_path("../Abstract/abstract-tideways-php-extension", __dir__)
+
+class TidewaysPhpAT81 < AbstractTidewaysPhpExtension
+  init
+  desc "Tideways PHP Profiler"
+  homepage "https://tideways.com"
+  url "https://s3-eu-west-1.amazonaws.com/tideways/extension/5.5.18/tideways-php-5.5.18-macos-arm.tar.gz"
+  sha256 "70362477568fd38edbc0178978481b6feed04b0b8d34667b77ef014dd3033010"
+
+  def install
+    prefix.install "tideways-php-#{php_version}.so"
+    write_config_file
+  end
+end

--- a/Formula/tideways-php@8.2.rb
+++ b/Formula/tideways-php@8.2.rb
@@ -1,0 +1,17 @@
+# typed: false
+# frozen_string_literal: true
+
+require File.expand_path("../Abstract/abstract-tideways-php-extension", __dir__)
+
+class TidewaysPhpAT82 < AbstractTidewaysPhpExtension
+  init
+  desc "Tideways PHP Profiler"
+  homepage "https://tideways.com"
+  url "https://s3-eu-west-1.amazonaws.com/tideways/extension/5.5.18/tideways-php-5.5.18-macos-arm.tar.gz"
+  sha256 "70362477568fd38edbc0178978481b6feed04b0b8d34667b77ef014dd3033010"
+
+  def install
+    prefix.install "tideways-php-#{php_version}.so"
+    write_config_file
+  end
+end

--- a/Formula/tideways-php@8.2.rb
+++ b/Formula/tideways-php@8.2.rb
@@ -5,10 +5,9 @@ require File.expand_path("../Abstract/abstract-tideways-php-extension", __dir__)
 
 class TidewaysPhpAT82 < AbstractTidewaysPhpExtension
   init
-  desc "Tideways PHP Profiler"
-  homepage "https://tideways.com"
   url "https://s3-eu-west-1.amazonaws.com/tideways/extension/5.5.18/tideways-php-5.5.18-macos-arm.tar.gz"
   sha256 "70362477568fd38edbc0178978481b6feed04b0b8d34667b77ef014dd3033010"
+  version "5.5.18"
 
   def install
     prefix.install "tideways-php-#{php_version}.so"


### PR DESCRIPTION
Based on https://github.com/shivammathur/homebrew-extensions/tree/master as template.

Install tideways-php for PHP 8.0 to 8.2

* Works with homebrew-core PHP formulas 8.0 - 8.2 now
* Sets `tideways.connection=tcp://127.0.0.1:9135` automatically to match tideways-daemon formula