### PR TITLE
Fix installing formulas when attr_rw is not available

### DIFF
--- a/Abstract/abstract-tideways-php-extension.rb
+++ b/Abstract/abstract-tideways-php-extension.rb
@@ -69,7 +69,7 @@ class AbstractTidewaysPhpExtension < Formula
   class << self
     attr_reader :php_version, :extension
 
-    attr_rw :priority
+    attr_accessor :priority
 
     def parse_extension(matches)
       @extension = matches[1].downcase if matches


### PR DESCRIPTION
### Reproduce

```
brew reinstall tideways-php@8.3.rb
Error: tideways/profiler/tideways-php@8.3.rb: undefined method `attr_rw' for class #<Class:AbstractTidewaysPhpExtension>
```

### Reason

Upstream change: https://github.com/Homebrew/brew/pull/19359/files

Impact in other projects: https://github.com/MaterializeInc/homebrew-crosstools/pull/12

### Validating the fix

```
export HOMEBREW_VERBOSE=1
export HOMEBREW_DEBUG=1
export HOMEBREW_NO_AUTO_UPDATE=1
export HOMEBREW_NO_INSTALL_FROM_API=1

cd Formula
brew reinstall ./tideways-php@8.3.rb
```