### PR TITLE
Use stdout logging for Tideways daemon

### DIFF
--- a/Formula/tideways-daemon.rb
+++ b/Formula/tideways-daemon.rb
@@ -23,13 +23,15 @@ class TidewaysDaemon < Formula
 
     def install
         bin.install 'tideways-daemon'
+    end
 
-        log_dir = var+'log/tideways'
-        log_dir.mkpath unless log_dir.exist?
+    def post_install
+        (var/"log/tideways").mkpath
     end
 
     service do
-        run [opt_bin/"tideways-daemon", "--address", "127.0.0.1:9135", "--log", HOMEBREW_PREFIX/"var/log/tideways/daemon.log", "--env", "development"]
+        run [opt_bin/"tideways-daemon", "--address", "127.0.0.1:9135", "--env", "development"]
+        log_path var/"log/tideways/daemon.log"
     end
 
     def caveats

--- a/scripts/update_formula.php
+++ b/scripts/update_formula.php
@@ -94,13 +94,15 @@ file_put_contents(
 
             def install
                 bin.install 'tideways-daemon'
+            end
 
-                log_dir = var+'log/tideways'
-                log_dir.mkpath unless log_dir.exist?
+            def post_install
+                (var/"log/tideways").mkpath
             end
 
             service do
-                run [opt_bin/"tideways-daemon", "--address", "127.0.0.1:9135", "--log", HOMEBREW_PREFIX/"var/log/tideways/daemon.log", "--env", "development"]
+                run [opt_bin/"tideways-daemon", "--address", "127.0.0.1:9135", "--env", "development"]
+                log_path var/"log/tideways/daemon.log"
             end
 
             def caveats


### PR DESCRIPTION
This makes the command to manually start the daemon more convenient to use, since the logs will be immediately visible:

    Or, if you don't want/need a background service you can just run:
      /home/linuxbrew/.linuxbrew/opt/tideways-daemon/bin/tideways-daemon --address 127.0.0.1:9135 --env development

But when using `brew services start tideways-daemon` the logs will go into the log-file as usual.